### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ white label implementation of the service.
 
 ## Getting Started
 
-Refer to the Integration Guide in the [FlyBuy Documentation][5] to get started. The iOS SDK is available for download in this repo's [Releases][5].
+Refer to the Integration Guide in the [FlyBuy Documentation][6] to get started. The iOS SDK is available for download in this repo's [Releases][5].
 
 ## Issues
 


### PR DESCRIPTION
Currently FlyBuy Documentation is linked to the releases instead of the correct url:

https://www.radiusnetworks.com/developers/flybuy/#/?id=flybuy-developer-documentation

As a user I need to inspect the README file to fins out the link.